### PR TITLE
update json-schema-deref-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "debug": "^2.6.0",
     "jayschema": "^0.3.1",
-    "json-schema-deref-sync": "^0.3.3",
+    "json-schema-deref-sync": "^0.8.0",
     "koa-bodyparser": "^3.2.0",
     "routington": "^1.0.3"
   },


### PR DESCRIPTION
Please consider this PR and create a new npm because of a npm audit warning in version 1.0.4:

```
# npm audit

                       === npm audit security report ===


                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance


  Moderate        Prototype Pollution

  Package         mpath

  Patched in      >=0.5.1

  Dependency of   koa-swagger2

  Path            koa-swagger2 > json-schema-deref-sync > mpath

  More info       https://nodesecurity.io/advisories/779
```